### PR TITLE
Clear style free memory

### DIFF
--- a/oolong/styling.c
+++ b/oolong/styling.c
@@ -40,12 +40,18 @@ oolong_error_t oolong_style_set_add(oolong_style_set_t** style_set, oolong_style
 {
     if (style_set == NULL)
         return oolong_error_record(OOLONG_ERROR_INVALID_ARGUMENT);
+
+    if (style == OOLONG_STYLE_CLEAR)
+    {
+        oolong_style_set_destroy(*style_set);
+        *style_set = oolong_style_set_create();
+        return OOLONG_ERROR_NONE;
+    }
     
-    size_t length = 0;
-    for (; (*style_set)[length] != L'\0'; length++);
+    size_t set_length = wcslen(*style_set);
     size_t style_length = wcslen(style_escapes[style]) + 1;
     
-    oolong_style_set_t* new_set = reallocarray(*style_set, length + style_length, sizeof(oolong_style_t));
+    oolong_style_set_t* new_set = reallocarray(*style_set, set_length + style_length, sizeof(oolong_style_t));
 
     if (new_set == NULL)
         return oolong_error_record(OOLONG_ERROR_NOT_ENOUGH_MEMORY);
@@ -53,10 +59,8 @@ oolong_error_t oolong_style_set_add(oolong_style_set_t** style_set, oolong_style
     *style_set = new_set;
 
     for (size_t i = 0; i < style_length; i++)
-        (*style_set)[i + length] = style_escapes[style][i];
+        (*style_set)[i + set_length] = style_escapes[style][i];
     
-    /* Probably not needed, but gives peace of mind. :D */
-    // (*style_set)[length + style_length - 1] = L'\0';
     return OOLONG_ERROR_NONE;
 }
 

--- a/oolong/styling.h
+++ b/oolong/styling.h
@@ -10,7 +10,7 @@
 #include "error.h"
 #include "escapes.h"
 
-#define OOLONG_STYLE_CLEAR_STRING (wchar_t*)U"\033[0m"
+#define OOLONG_STYLE_CLEAR_STRING L"\033[0m"
 
 enum oolong_style_e
 {


### PR DESCRIPTION
When the `OOLONG_STYLE_CLEAR` enum value is passed into `oolong_style_set_add()` it would simply add onto the end, which gave the desired result but did so while consuming more memory that needed. This PR has the `oolong_style_set_add()` function destroy the given style set and create a new empty set in its place.